### PR TITLE
Fixed custom endpoints not being marked as custom

### DIFF
--- a/Web API Library/AppSrc/WebApi/cWebApiCustomEndpoint.pkg
+++ b/Web API Library/AppSrc/WebApi/cWebApiCustomEndpoint.pkg
@@ -67,6 +67,11 @@ Class cWebApiCustomEndpoint is a cBaseRestDataset
         Forward Send Construct_Object       
     End_Procedure
     
+    Procedure OnHttpRequest tWebApiCallContext ByRef webapicallcontext
+        Forward Send OnHttpRequest (&webapicallcontext)
+        Move True to webapicallcontext.bIsCustom
+    End_Procedure
+    
     //Augment this in your custom endpoint to include all the OpenApi specification information
     //This only needs to be filled when you want to include your custom endpoint in the OpenApi specification
     { MethodType = Event }


### PR DESCRIPTION
Custom endpoints were not properly being marked as custom. This caused iterators to append their own headers such as "content-type: application/json" which messed with file downloads.