### PR TITLE
Allow readonly to work for cRestEntity and cRestChildCollection

### DIFF
--- a/Web API Library/AppSrc/WebApi/cOpenApiSpecification.pkg
+++ b/Web API Library/AppSrc/WebApi/cOpenApiSpecification.pkg
@@ -1103,6 +1103,7 @@ Class cOpenApiSpecification is a cObject
             Move (IsObjectOfClass(hoField, RefClass(cRestChildCollection))) to bIsChildCollection
             
             Get SchemaName of hoField to sNestedSchemaName
+            Get pbReadOnly of hoField to bReadOnly
             
             //Initialize the nested schema
             Get Create (RefClass(cJsonObject)) to hoNestedSchema
@@ -1138,6 +1139,10 @@ Class cOpenApiSpecification is a cObject
                 //For the entity its sufficient to mark it as type object and append the list of properties (fields)
                 Send SetMemberValue of hoNestedSchema "type" jsonTypeString "object"
                 Send SetMember of hoNestedSchema "properties" hoNestedSchemaProperties    
+            End
+            
+            If bReadOnly Begin
+                Send SetMemberValue of hoNestedSchema "readOnly" jsonTypeBoolean True
             End
             //Append the nested schema to the actual schema
             Send SetMember of hoPropertiesJson sNestedSchemaName hoNestedSchema

--- a/Web API Sample/AppSrc/OrdersEndpoint.pkg
+++ b/Web API Sample/AppSrc/OrdersEndpoint.pkg
@@ -6,8 +6,7 @@ Use WebApi\cRestField.pkg
 
 Object oOrdersEndpoint is a cRestDataset
     Set psPath to "Orders"
-    
-    Set pbReadOnly to True
+    Set pbReadOnly to False
     
     Object oSalesPerson_DD is a cSalesPersonDataDictionary
     End_Object
@@ -23,24 +22,57 @@ Object oOrdersEndpoint is a cRestDataset
     Set Main_DD to oOrderHeader_DD
     Set Server to oOrderHeader_DD
 
+    Object oOrderHeader_Order_Number is a cRestField
+        Entry_Item OrderHeader.Order_Number
+        Set pbReadOnly to True
+    End_Object
+    
     Object oOrderHeader_Order_Date is a cRestField
         Entry_Item OrderHeader.Order_Date
     End_Object
 
-    Object oOrderHeader_Terms is a cRestField
-        Entry_Item OrderHeader.Terms
+    Object oOrderHeader_Customer_Number is a cRestField
+        Entry_Item OrderHeader.Customer_Number
+        Set pbWriteOnly to True
+        Set psFieldName to "Customer_Number"
     End_Object
 
-    Object oOrderHeader_Ship_Via is a cRestField
-        Entry_Item OrderHeader.Ship_Via
+    Object oOrderHeader_SalesPerson_ID is a cRestField
+        Entry_Item OrderHeader.SalesPerson_ID
+        Set pbWriteOnly to True
+        Set psFieldName to "SalesPerson_ID"
+    End_Object    
+    
+    Object oCustomerEntity is a cRestEntity
+        Set Server to oCustomer_DD
+        Set pbReadOnly to True
+
+        Object oCustomer_Name is a cRestField
+            Entry_Item Customer.Name
+        End_Object
+
+        Object oCustomer_Address is a cRestField
+            Entry_Item Customer.Address
+        End_Object
+
+        Object oCustomer_City is a cRestField
+            Entry_Item Customer.City
+        End_Object        
+        
+    End_Object
+    
+    Object oSalesPersonEntity is a cRestEntity
+        Set Server to oSalesPerson_DD
+        Set pbReadOnly to True
+        
+        Object oSalesPerson_Name is a cRestField
+            Entry_Item SalesPerson.Name
+        End_Object       
+        
     End_Object
 
     Object oOrderHeader_Order_Total is a cRestField
         Entry_Item OrderHeader.Order_Total
-    End_Object
-    
-    
-    
-    
-    
+        Set pbReadOnly to True
+    End_Object  
 End_Object


### PR DESCRIPTION
You might want to hide the cRestEntity and cRestChildCollections during a post request, this allows you to do so.