### PR TITLE
Fixed validation tables being grabbed from wrong field

### DIFF
--- a/Web API Library/AppSrc/WebApi/cBaseWebApiIterator.pkg
+++ b/Web API Library/AppSrc/WebApi/cBaseWebApiIterator.pkg
@@ -64,9 +64,4 @@ Class cBaseWebApiIterator is a cObject
         //Should be augmented in iterators
         Error DFERR_PROGRAM "Override this Procedure"
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cJSONIterator.pkg
+++ b/Web API Library/AppSrc/WebApi/cJSONIterator.pkg
@@ -176,10 +176,4 @@ Class cJSONIterator is a cBaseWebApiIterator
         // Destroy the JSON handle at the end
         Send Destroy of hoJson
     End_Procedure
-
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cOpenApiEndpoint.pkg
+++ b/Web API Library/AppSrc/WebApi/cOpenApiEndpoint.pkg
@@ -23,10 +23,4 @@ Class cOpenApiEndpoint is a cBaseRestDataset
         Move C_WEBAPI_OK to webapicallcontext.iStatusCode
         Move "OK" to webapicallcontext.sShortStatusMessage
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cOpenApiRestField.pkg
+++ b/Web API Library/AppSrc/WebApi/cOpenApiRestField.pkg
@@ -19,10 +19,4 @@ Class cOpenApiRestField is a cRestField
         //Get the OpenApi specification        
         Get GenerateOpenApiSpec of oOpenApiGenerator to sValue
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cOpenApiSpecification.pkg
+++ b/Web API Library/AppSrc/WebApi/cOpenApiSpecification.pkg
@@ -1335,9 +1335,4 @@ Class cOpenApiSpecification is a cObject
         //If we get here hoParent should be the cWebApi object
         Function_Return hoParent
     End_Function
-    
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cRestChildCollection.pkg
+++ b/Web API Library/AppSrc/WebApi/cRestChildCollection.pkg
@@ -103,9 +103,4 @@ Class cRestChildCollection is a cObject
     Function IsRequired Returns Boolean
         Function_Return False
     End_Function
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cRestDataset.pkg
+++ b/Web API Library/AppSrc/WebApi/cRestDataset.pkg
@@ -623,10 +623,4 @@ Class cRestDataset is a cBaseRestDataset
         
         Function_Return sDDErrorMessage
     End_Function
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-        
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cRestField.pkg
+++ b/Web API Library/AppSrc/WebApi/cRestField.pkg
@@ -244,7 +244,7 @@ Class cRestField is a cObject
         Variant[][2] avValidationTable
         Handle hoValidationTable hoDD
         
-        Get Main_DD to hoDD
+        Get Server to hoDD
         Get Data_Field to iField
         
         //Fields that have no data binding cannot have a validation table
@@ -315,10 +315,4 @@ Class cRestField is a cObject
         
         Function_Return bRequired
     End_Function
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-
-    End_Procedure
-    
 End_Class

--- a/Web API Library/AppSrc/WebApi/cRest_Mixin.pkg
+++ b/Web API Library/AppSrc/WebApi/cRest_Mixin.pkg
@@ -7,8 +7,8 @@
     // Locate_Server and Server are used so that child objects can resolve 
     // that a server does not exit.
     { Visibility=Private }
-    Function Locate_Server Returns Handle
-        Function_Return 0
+    Function Locate_Server Returns Integer
+        Function_Return (Server(Self))
     End_Function
     
     

--- a/Web API Library/AppSrc/WebApi/cSwaggerUI.pkg
+++ b/Web API Library/AppSrc/WebApi/cSwaggerUI.pkg
@@ -12,9 +12,4 @@ Class cSwaggerUI is a cWebBaseControl
         Set psJSClass to "df.SwaggerUI"
         Set pbShowLabel to False
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cWebApiCustomEndpoint.pkg
+++ b/Web API Library/AppSrc/WebApi/cWebApiCustomEndpoint.pkg
@@ -77,10 +77,4 @@ Class cWebApiCustomEndpoint is a cBaseRestDataset
     { MethodType = Event }
     Procedure OnDefineSchema tEndpointDefinition ByRef endpointDefinition
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cWebApiLoginEndpoint.pkg
+++ b/Web API Library/AppSrc/WebApi/cWebApiLoginEndpoint.pkg
@@ -121,10 +121,4 @@ Class cWebApiLoginEndpoint is a cBaseRestDataset
     {MethodType=Event}
     Procedure OnSuccessfulLogin tWebApiCallContext ByRef webapicallcontext
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cWebApiRoutableHost_Mixin.pkg
+++ b/Web API Library/AppSrc/WebApi/cWebApiRoutableHost_Mixin.pkg
@@ -73,10 +73,4 @@ Class cWebApiRoutableHost_Mixin is a Mixin
         
         Function_Return iIndex
     End_Function
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-
-    End_Procedure
-
 End_Class

--- a/Web API Library/AppSrc/WebApi/cXMLIterator.pkg
+++ b/Web API Library/AppSrc/WebApi/cXMLIterator.pkg
@@ -180,9 +180,4 @@ Class cXMLIterator is a cBaseWebApiIterator
         Loop
         
     End_Procedure
-
-    Procedure End_Construct_Object
-        Forward Send End_Construct_Object
-    End_Procedure
-
 End_Class


### PR DESCRIPTION
- Validation tables are now retrieved based on the server and not Main_DD. 
- Removed unused End_Construct_Objects